### PR TITLE
Add library path for qwt

### DIFF
--- a/cmake/FindQWT.cmake
+++ b/cmake/FindQWT.cmake
@@ -14,7 +14,7 @@ if(QWT_INCLUDE_DIR)
 endif(QWT_INCLUDE_DIR)
 
 SET(QWT_NAMES qwt-qt4 qwt)
-FIND_LIBRARY(QWT_LIBRARY NAMES ${QWT_NAMES})
+FIND_LIBRARY(QWT_LIBRARY NAMES ${QWT_NAMES} PATHS /usr/lib /usr/lib/qwt)
 find_path(QWT_INCLUDE_DIR NAMES qwt.h
     PATH_SUFFIXES qwt-qt4 qwt5 qwt
     HINTS /usr/local/Frameworks


### PR DESCRIPTION
On Arch Linux qwt libs are found in /usr/lib/qwt, which does not seem to be included in the default search path.