### PR TITLE
Bugfixes in SonarWidget

### DIFF
--- a/src/sonar_widget/SonarPlot.cc
+++ b/src/sonar_widget/SonarPlot.cc
@@ -3,7 +3,7 @@
 
 
 SonarPlot::SonarPlot(QWidget *parent)
-    : QFrame(parent), mChangedSize(true),scaleX(1),scaleY(1),range(5)
+    : QFrame(parent), mChangedSize(true),scaleX(1),scaleY(1),number_of_bins(866),range(5)
 {
   int alpha = 255;
   for(int i=0;i<64;i++){
@@ -35,6 +35,15 @@ void SonarPlot::setData(const base::samples::SonarScan scan)
   if(!mSonarScan.number_of_bins || !mSonarScan.number_of_beams){
     return;
   }
+  
+  //The beams need to be stored by column
+  // If not -> toggle the memory-layout
+  if(!mSonarScan.memory_layout_column)
+  {
+    mSonarScan.toggleMemoryLayout();
+  }
+  
+  number_of_bins = mSonarScan.number_of_bins;
   if(mChangedSize){
     mRawPoints.clear();
     for(uint i=0;i<mSonarScan.data.size();i++){
@@ -69,13 +78,14 @@ void SonarPlot::paintEvent(QPaintEvent *)
 
 void SonarPlot::resizeEvent ( QResizeEvent * event )
 {
+  //Calculate the image/bin-scalling based on the number of bins
   scaleX = 0.2;
   if(width()>400){
-    scaleX = double((width()-134))/866;
+    scaleX = double((width()-134))/ (number_of_bins*4.0);
   }
   scaleY = 0.2;
   if(height()>200){
-    scaleY = double((height()-100))/500;
+    scaleY = double((height()-100))/ (number_of_bins*2.0);
   } 
   fillPoints();
   QWidget::resizeEvent (event);

--- a/src/sonar_widget/SonarPlot.h
+++ b/src/sonar_widget/SonarPlot.h
@@ -25,6 +25,7 @@ protected:
     QList<QPoint> mPoints;
     double scaleX;
     double scaleY;
+    int number_of_bins; //Number of bins in a single beam
     int range;
     QVector<QColor> colorMap;
     


### PR DESCRIPTION
I fixed two bugs in the SonarWidget for Multibeam-scans:

1. The image-scalling was based on a fixed number of bins (866) in the single Beams. If you have SonarScans with a higher number of bins, the scalling does not work and the beams are cut off by the frame-borders, which makes this widget unusable for SonarScans with a higher resolution or range. 
In the fix I simply use the number_of_bins to calculate the scalling-factor.
2. The widget ignores the memory_layout_column Flag of the SonarScan, which describes the memory layout (if the beams are organized per row or column in the memory). The widget assumes that the beams are always organized per column, which is wrong. I added a check of the Flag and toggle the memory-layout, if needed. 

I tested the fix with some data from a gemini multibeam-sonar and it worked fine.