### PR TITLE
changes sonar widget to fill all pixels instead of displaying rays

### DIFF
--- a/src/sonar_widget/SonarPlot.cc
+++ b/src/sonar_widget/SonarPlot.cc
@@ -1,9 +1,10 @@
 #include "./SonarPlot.h"
 #include <iostream>
 
+using namespace std;
 
 SonarPlot::SonarPlot(QWidget *parent)
-    : QFrame(parent), mChangedSize(true),scaleX(1),scaleY(1),number_of_bins(866),range(5)
+    : QFrame(parent), changedSize(true),scaleX(1),scaleY(1),range(5)
 {
   int alpha = 255;
   for(int i=0;i<64;i++){
@@ -30,31 +31,41 @@ SonarPlot::~SonarPlot()
 
 void SonarPlot::setData(const base::samples::SonarScan scan)
 {
-  std::cout << "setData, number of beams " <<mSonarScan.number_of_beams <<" number of bins " << mSonarScan.number_of_bins <<std::endl;
-  mSonarScan = scan;
-  if(!mSonarScan.number_of_bins || !mSonarScan.number_of_beams){
+  lastSonarScan = sonarScan;
+  lastSonarScan.data.clear();
+  sonarScan = scan;
+  if(!sonarScan.number_of_bins || !sonarScan.number_of_beams){
     return;
   }
-  
-  //The beams need to be stored by column
-  // If not -> toggle the memory-layout
-  if(!mSonarScan.memory_layout_column)
-  {
-    mSonarScan.toggleMemoryLayout();
-  }
-  
-  number_of_bins = mSonarScan.number_of_bins;
-  if(mChangedSize){
-    mRawPoints.clear();
-    for(uint i=0;i<mSonarScan.data.size();i++){
-      base::Angle ang = int(i/mSonarScan.number_of_bins)*mSonarScan.angular_resolution-mSonarScan.start_bearing;
-      int radius = i % mSonarScan.number_of_bins;
-      uint x = radius*sin(ang.getRad());
-      uint y = radius*cos(ang.getRad());
-      mRawPoints.append(QPoint(x,y));
+  if(changedSize
+    || !(sonarScan.start_bearing == lastSonarScan.start_bearing)
+    || !(sonarScan.angular_resolution == lastSonarScan.angular_resolution)
+    || !(sonarScan.number_of_beams == lastSonarScan.number_of_beams)
+    || !(sonarScan.number_of_bins == lastSonarScan.number_of_bins)){
+    pixelList.clear();
+    for (int i = 0; i< width();i++){
+        for (int j = 0; j< origin.y();j++){
+            QPoint point(i,j);
+            point -= origin;
+            point.rx()/=scaleX*BINS_REF_SIZE/sonarScan.number_of_bins;
+            point.ry()/=scaleY*BINS_REF_SIZE/sonarScan.number_of_bins;
+            int radius = sqrt(point.x()*point.x() + point.y()*point.y());
+            base::Angle angle = base::Angle::fromDeg(0);
+            if(radius){
+                angle = base::Angle::fromRad(asin(double(point.x())/radius));
+            }
+            if(radius <= sonarScan.number_of_bins && fabs(angle.getDeg()) <= fabs(sonarScan.start_bearing.getDeg())){
+                uint index = abs(int((angle-sonarScan.start_bearing).getDeg()/sonarScan.angular_resolution.getDeg()))*sonarScan.number_of_bins + radius;
+                if(index<=sonarScan.data.size()){
+                    SonarPlotPixel sonarPlotPixel;
+                    sonarPlotPixel.point = QPoint(i,j);
+                    sonarPlotPixel.index = index;
+                    pixelList.append(sonarPlotPixel);
+                }
+            }
+        }
     }
-    fillPoints();
-    mChangedSize=false;
+    changedSize=false;
  }
  update();
 }
@@ -62,33 +73,30 @@ void SonarPlot::setData(const base::samples::SonarScan scan)
 
 void SonarPlot::paintEvent(QPaintEvent *)
 {
-    if(mPoints.size()!=mSonarScan.data.size()){
-      std::cout <<"mPoints.size()!=mSonarScan.data.size() mPoints.size(): " <<mPoints.size() <<" mSonarScan.data.size(): " <<mSonarScan.data.size() <<endl;
-      return;
-    }
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
-    for(uint i=0;i<mSonarScan.data.size();i++){
-      painter.setPen(QPen(colorMap[ mSonarScan.data[i] ]));
-      painter.drawPoint(mPoints[i]);
-    }    
+    for(int i=0;i<pixelList.size();i++){
+        painter.setPen(QPen(colorMap[sonarScan.data[pixelList[i].index]]));
+        painter.drawPoint(pixelList[i].point);
+    }
     drawOverlay();
     
 }
 
 void SonarPlot::resizeEvent ( QResizeEvent * event )
 {
-  //Calculate the image/bin-scalling based on the number of bins
-  scaleX = 0.2;
-  if(width()>400){
-    scaleX = double((width()-134))/ (number_of_bins*4.0);
-  }
-  scaleY = 0.2;
-  if(height()>200){
-    scaleY = double((height()-100))/ (number_of_bins*2.0);
-  } 
-  fillPoints();
-  QWidget::resizeEvent (event);
+    scaleX = 0.2;
+    if(width()>400){
+        scaleX = double(width())/(BASE_WIDTH-134);
+    }
+    scaleY = 0.2;
+    if(height()>200){
+        scaleY = double(height()-100)/(BASE_HEIGHT-100);
+    } 
+    origin.setX(width()/2);
+    origin.setY(height()-30);
+    changedSize=true;
+    QWidget::resizeEvent (event);
 }
 
 void SonarPlot::drawOverlay()
@@ -96,23 +104,18 @@ void SonarPlot::drawOverlay()
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setPen(QPen(Qt::white));
-    QPoint origin;
-    origin.setX(width()/2);
-    origin.setY(height()-30);
     for(int i=1;i<=5;i++){
-      int angle = 120;
-      painter.drawArc(width()/2-i*scaleX*100,height()-30-i*scaleY*100,i*200*scaleX,i*200*scaleY,(90-angle/2)*16,angle*16);
+      base::Angle sectorSize = sonarScan.angular_resolution*(sonarScan.number_of_beams-1);
+      painter.drawArc(width()/2-i*scaleX*100,height()-30-i*scaleY*100,i*200*scaleX,i*200*scaleY,(90-sectorSize.getDeg()/2)*16,sectorSize.getDeg()*16);
       QString str;
       str.setNum(i*range/5);
-      int x = width()/2+i*100*scaleX*sin(angle*3.1416/360);
-      int y = height()-i*100*scaleY*cos(angle*3.1416/360);
-      painter.drawText(x,y-5,str);
-      
-      base::Angle sectorSize = mSonarScan.angular_resolution*mSonarScan.number_of_beams;
+      int x = width()/2+i*100*scaleX*sin(sectorSize.getDeg()*3.1416/360);
+      int y = height()-i*100*scaleY*cos(sectorSize.getDeg()*3.1416/360);
+      painter.drawText(x,y-5,str);      
       base::Angle ang = sectorSize*(-0.5+(i-1)*0.25);
       QPoint p2;
-      x = width()/2+mSonarScan.number_of_bins*sin(ang.getRad())*scaleX;
-      y = height()-30-mSonarScan.number_of_bins*cos(ang.getRad())*scaleY;
+      x = width()/2+BINS_REF_SIZE*sin(ang.getRad())*scaleX;
+      y = height()-30-BINS_REF_SIZE*cos(ang.getRad())*scaleY;
       p2.setX(x);
       p2.setY(y);
       painter.drawLine(origin,p2);     
@@ -132,16 +135,6 @@ void SonarPlot::drawOverlay()
       painter.setBrush(QBrush(colorMap[i]));
       painter.drawRect(width()-30,height()-10-i*2,20,2);
     }
-}
-
-void SonarPlot::fillPoints()
-{
-  mPoints.clear();
-  uint w = width()/2;
-  uint h = height()-30; 
-  for(uint i=0;i<mRawPoints.size();i++){
-      mPoints.append(QPoint(w+mRawPoints[i].x()*scaleX,h-mRawPoints[i].y()*scaleY));
-  }
 }
 
 void SonarPlot::rangeChanged(int value)

--- a/src/sonar_widget/SonarPlot.h
+++ b/src/sonar_widget/SonarPlot.h
@@ -35,3 +35,4 @@ protected slots:
 
 
 #endif
+

--- a/src/sonar_widget/SonarPlot.h
+++ b/src/sonar_widget/SonarPlot.h
@@ -5,6 +5,16 @@
 #include <QFrame>
 #include "base/samples/sonar_scan.h"
 
+
+#define BASE_WIDTH      1300
+#define BASE_HEIGHT      600
+#define BINS_REF_SIZE    500
+
+struct SonarPlotPixel{
+    QPoint point;
+    uint index;
+};
+
 class SonarPlot : public QFrame
 {
     Q_OBJECT
@@ -18,16 +28,15 @@ protected:
     void paintEvent(QPaintEvent *event);
     void resizeEvent ( QResizeEvent * event );
     void drawOverlay();
-    void fillPoints();
-    base::samples::SonarScan mSonarScan;
-    bool mChangedSize;
-    QList<QPoint> mRawPoints;
-    QList<QPoint> mPoints;
+    base::samples::SonarScan sonarScan;
+    base::samples::SonarScan lastSonarScan;
+    bool changedSize;
     double scaleX;
     double scaleY;
-    int number_of_bins; //Number of bins in a single beam
     int range;
     QVector<QColor> colorMap;
+    QList<SonarPlotPixel> pixelList;
+    QPoint origin;
     
 protected slots:
     void rangeChanged(int);
@@ -36,4 +45,3 @@ protected slots:
 
 
 #endif
-

--- a/src/sonar_widget/SonarWidget.cc
+++ b/src/sonar_widget/SonarWidget.cc
@@ -11,7 +11,7 @@ SonarWidget::SonarWidget(QWidget *parent)
     resize(1020,670);
     
     plot = new SonarPlot(this);
-    plot->setGeometry (10,10,1000,600);
+    plot->setGeometry (10,10,BASE_WIDTH,BASE_HEIGHT);
     connect(this,SIGNAL(rangeChanged(int)),plot,SLOT(rangeChanged(int)));
     
     QPalette Pal(palette());


### PR DESCRIPTION
Hi,

I changed the sonar widget to interpolate and fill all pixels within the range instead of displaying rays as it did before. I saw that there were some other changes made in the original repository by fzachert.
I haven't merged these yet.
Sitta