### PR TITLE
set vtk to optional

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,7 +10,7 @@
   <depend package="drivers/aggregator" />
   <depend package="freeglut3" />
   <depend package="qwt5" />
-  <depend package="vtk-qt4" />
+  <depend package="vtk-qt4" optional="1"/>
   <rosdep name="qt4" />
   <rosdep name="qt4-opengl" />
   <versioncontrol type="git" url="" />


### PR DESCRIPTION
Currently building stable fails on debian testing and 16.04 because vtk-qt4 is not available for these systems.

The CMakeLists.txt already used the USE_VTK flag., so picking this from master shouldn't be an issue