### PR TITLE
make the qwt5 dependency optional

### DIFF
--- a/cmake/FindQWT.cmake
+++ b/cmake/FindQWT.cmake
@@ -46,7 +46,7 @@
 find_path ( QWT_INCLUDE_DIR
   NAMES qwt_plot.h
   HINTS ${QT_INCLUDE_DIR} /usr/local/lib/qwt.framework/Headers
-  PATH_SUFFIXES qwt qwt-qt3 qwt-qt4 qwt-qt5
+  PATH_SUFFIXES qwt-qt4
 )
 
 set ( QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR} )

--- a/manifest.xml
+++ b/manifest.xml
@@ -9,7 +9,7 @@
   <depend package="image_processing/frame_helper" />
   <depend package="drivers/aggregator" />
   <depend package="freeglut3" />
-  <depend package="qwt5" />
+  <depend_optional package="qwt5" />
   <depend package="vtk-qt4" optional="1"/>
   <rosdep name="qt4" />
   <rosdep name="qt4-opengl" />

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,23 +49,19 @@ SET(COLLECTION_MOC_HDRS
   range_view/RangeViewGL.h
   range_view/RangeViewPlugin.h
   RockWidgetCollection.h
-  artificial_horizon/artificialhorizon.h
-  artificial_horizon/artificialhorizonplugin.h
   multi_view/MultiViewWidget.h
   multi_view/WidgetButton.h
   multi_view/MultiViewPlugin.h
   multi_view/MultiWidget.h
   multi_view/MultiWidgetPlugin.h
   multi_view/WidgetButtonPlugin.h
-  artificial_horizon/compass.h
-  artificial_horizon/compassplugin.h
-  artificial_horizon/orientation.h
-  artificial_horizon/orientationplugin.h
   virtual_joystick/VirtualJoystick.h  
   virtual_joystick/VirtualJoystickPlugin.h
   generic_widgets/PaintWidget.h
   generic_widgets/RockSlider.h
   generic_widgets/RockSliderPlugin.h
+  artificial_horizon/artificialhorizon.h
+  artificial_horizon/artificialhorizonplugin.h
   plot2d/Plot2d.h
   plot2d/qcustomplot.h
   plot2d/Plot2dPlugin.h
@@ -103,17 +99,15 @@ SET(COLLECTION_HDRS
   range_view/RangeView.h
   range_view/RangeViewGL.h
   RockWidgetCollection.h
-  artificial_horizon/artificialhorizon.h
   multi_view/MultiViewWidget.h
   multi_view/WidgetButton.h
   multi_view/MultiWidget.h
-  artificial_horizon/compass.h
-  artificial_horizon/orientation.h
   virtual_joystick/VirtualJoystick.h  
   generic_widgets/PaintWidget.h
   generic_widgets/RockSlider.h
   plot2d/Plot2d.h
   plot2d/qcustomplot.h
+  artificial_horizon/artificialhorizon.h
   2dvis/qwaterfalldisplay.h
   generic_widgets/RockSliderPlugin.h
   timeline/Timeline.h
@@ -133,7 +127,6 @@ FILE(GLOB COLLECTION_SOURCES
     range_view/*.cc 
     image_view_old/*.cc 
     sonar_view/*.cc 
-    artificial_horizon/*.cc 
     multi_view/*.cc 
     generic_widgets/*.cc
     virtual_joystick/*.cc
@@ -144,6 +137,10 @@ FILE(GLOB COLLECTION_SOURCES
     progress_indicator/*.cc
     sonar_widget/*.cc
     *.cc)
+
+list(APPEND COLLECTION_SOURCES
+    artificial_horizon/artificialhorizon.cc
+    artificial_horizon/artificialhorizonplugin.cc)
     
 if (USE_VTK)
     find_package(VTK)
@@ -171,15 +168,33 @@ endif()
 SET(QtApp_RCCS resources.qrc)
 QT4_ADD_RESOURCES(QtApp_RCC_SRCS ${QtApp_RCCS})
 
+find_package(QWT)
+
+if (QWT_FOUND)
+    add_definitions(-DUSE_QWT)
+    list(APPEND EXTRA_DEPS QWT)
+    list(APPEND COLLECTION_SOURCES
+        artificial_horizon/compass.cc
+        artificial_horizon/compassplugin.cc
+        artificial_horizon/orientation.cc
+        artificial_horizon/orientationplugin.cc)
+    list(APPEND COLLECTION_MOC_HDRS
+        artificial_horizon/compass.h
+        artificial_horizon/compassplugin.h
+        artificial_horizon/orientation.h
+        artificial_horizon/orientationplugin.h)
+    list(APPEND COLLECTION_HDRS
+        artificial_horizon/orientation.h
+        artificial_horizon/compass.h)
+endif()
+
 rock_vizkit_widget(rock_widget_collection SHARED
     SOURCES ${COLLECTION_SOURCES} ${QtApp_RCC_SRCS} 
     HEADERS ${COLLECTION_HDRS}
     MOC ${COLLECTION_MOC_HDRS}
     DEPS_PKGCONFIG base-types base-lib frame_helper
-    DEPS_CMAKE QWT OpenGL ${VTK_DEPS}
-    LIBS ${QT_QTCORE_LIBRARY} ${VTK_LIBS} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY} ${QT_QTDESIGNER_LIBRARY} ${QTGSTREAMER_LIBRARIES} ${QTGSTREAMER_UI_LIBRARIES} 
-    )
-
+    DEPS_CMAKE OpenGL ${VTK_DEPS} ${EXTRA_DEPS}
+    LIBS ${QT_QTCORE_LIBRARY} ${VTK_LIBS} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY} ${QT_QTDESIGNER_LIBRARY} ${QTGSTREAMER_LIBRARIES} ${QTGSTREAMER_UI_LIBRARIES})
 
 add_subdirectory(stream_aligner_widget)
 

--- a/src/RockWidgetCollection.cc
+++ b/src/RockWidgetCollection.cc
@@ -4,7 +4,6 @@
 #include "sonar_view/SonarViewPlugin.h"
 #include "range_view/RangeViewPlugin.h"
 #include "artificial_horizon/artificialhorizonplugin.h"
-#include "artificial_horizon/compassplugin.h"
 #include "artificial_horizon/orientationplugin.h"
 #include "multi_view/MultiViewPlugin.h"
 #include "multi_view/MultiWidgetPlugin.h"
@@ -16,6 +15,10 @@
 #include "image_view/ImageViewPlugin.h"
 #include "progress_indicator/ProgressIndicatorPlugin.h"
 #include "sonar_widget/SonarWidgetPlugin.h"
+
+#ifdef USE_QWT
+#include "artificial_horizon/compassplugin.h"
+#endif
 
 #ifdef USE_VTK
 #include "vtk/sonar_display/SonarDisplayPlugin.h"
@@ -29,27 +32,28 @@ RockWidgetCollection::RockWidgetCollection(QObject *parent)
 {
 // *** Please sort these alphabetically after the displayed name! ***
    widgets.append(new ArtificialHorizonPlugin(this));
-   widgets.append(new CompassPlugin(this));
    widgets.append(new ImageViewPlugin(this));
    widgets.append(new ImageViewOldPlugin(this));
    widgets.append(new MultiViewPlugin(this));
    widgets.append(new MultiWidgetPlugin(this));
-   widgets.append(new OrientationPlugin(this));
    widgets.append(new Plot2dPlugin(this));
    widgets.append(new ProgressIndicatorPlugin(this));
    widgets.append(new RangeViewPlugin(this));
    widgets.append(new RockSliderPlugin(this));
-#ifdef USE_VTK
-   widgets.append(new SonarDisplayPlugin(this));
-#endif
    widgets.append(new SonarViewPlugin(this));
    widgets.append(new TimelinePlugin(this));
-#ifdef USE_VTK
-   widgets.append(new Vectorfield3DPlugin(this));
-#endif
    widgets.append(new VirtualJoystickPlugin(this));
    widgets.append(new WaterfallDisplayPlugin(this));
    widgets.append(new SonarWidgetPlugin(this));
+
+#ifdef USE_QWT
+   widgets.append(new CompassPlugin(this));
+   widgets.append(new OrientationPlugin(this));
+#endif
+#ifdef USE_VTK
+   widgets.append(new SonarDisplayPlugin(this));
+   widgets.append(new Vectorfield3DPlugin(this));
+#endif
 }
 
 QList<QDesignerCustomWidgetInterface*> RockWidgetCollection::customWidgets() const

--- a/src/artificial_horizon/compass.cc
+++ b/src/artificial_horizon/compass.cc
@@ -8,7 +8,6 @@
 #include <QLabel>
 #include <math.h>
 
-
 Compass::Compass(QWidget* parent): MultiWidget(parent)
 {
   // add a layout


### PR DESCRIPTION
The only widget that depends on it is the artificial horizon.
Unfortunately, this is a pretty common widget. We would _in fine_
need to reimplement it properly without qwt.

In the meantime, make sure we can build without QWT
installed. The qt4 and qt5 dev files for QWT cannot
be installed in parallel, which causes problems with
e.g. gazebo dev files.