### PR TITLE
Make it possible to display remission from a DepthMap using ImageView

### DIFF
--- a/src/image_view/ImageView.cc
+++ b/src/image_view/ImageView.cc
@@ -464,6 +464,25 @@ void ImageView::saveImage(QString path, bool overlay)
     saveImage.save(path, "PNG", 80);
 }
 
+void ImageView::setFrame(const base::samples::DepthMap &frame)
+{
+    // This just copies/converts remission values from the DepthMap to a Frame
+    // TODO For better visualization, the vertical and horizontal resolution of the DepthMap should be considered
+
+    base::samples::frame::Frame bframe(frame.horizontal_size, frame.vertical_size, 8);
+    uint8_t* ptr = bframe.getImagePtr();
+
+    for(std::vector<float>::const_iterator r=frame.remissions.begin(); r!=frame.remissions.end(); ++r)
+    {
+        *ptr++ = *r * 255;
+    }
+    if(1 == frame_converter.copyFrameToQImageRGB888(image,bframe)) {
+        LOG_WARN("Frame size changed while converting frame to QImage (says converter)");
+    }
+    processImage();
+    refresh();
+}
+
 void ImageView::setFrame(const base::samples::DistanceImage &frame)
 {  
 

--- a/src/image_view/ImageView.h
+++ b/src/image_view/ImageView.h
@@ -10,6 +10,7 @@
 
 #include <base/samples/Frame.hpp>
 #include <base/samples/DistanceImage.hpp>
+#include <base/samples/DepthMap.hpp>
 #include <frame_helper/FrameQImageConverter.h>
 #include "rock_widget_collection/progress_indicator/ProgressIndicator.h"
 
@@ -32,11 +33,11 @@
  * transformation the image might receive is going to be executed on the overlay as well.
  * For example: The overlays are immune to image rotation or scaling. They simple get scaled
  * and rotated as well.
- * Text overlays, on the other hand, are considered as status information. They are attatched
+ * Text overlays, on the other hand, are considered as status information. They are attached
  * to the widget and do not care about image transformation. Nevertheless, they react to widget
  * transformation, e.g. they keep their alignment to the assigned widget corner.
  * 
- * Overlays -- image- or widget attatched -- may be set persistent or volatile. Volatile overlays
+ * Overlays -- image- or widget attached -- may be set persistent or volatile. Volatile overlays
  * are being removed with the next frame update while persistent overlays stay until you remove
  * them. Currently, you can only remove all (persistent) overlays at once.
  * 
@@ -243,6 +244,7 @@ public slots:
      */
     void setFrame(const base::samples::DistanceImage &frame);
     void setFrame(const base::samples::frame::Frame &frame);
+    void setFrame(const base::samples::DepthMap &frame);
     void setImage(const QImage &image);
     void setRawImage(const QString &mode, int pixel_size, int width, int height,const char* pbuffer, const int size);
     void refresh();


### PR DESCRIPTION
A `DepthMap` often contains remission information (usually reflectance of IR light) which can be of interest.