### PR TITLE
remove QBrush color of QPainter

### DIFF
--- a/src/sonar_widget/SonarPlot.cc
+++ b/src/sonar_widget/SonarPlot.cc
@@ -160,7 +160,6 @@ void SonarPlot::drawOverlay()
     // draw color pallete
     for(size_t i = 0; i < 256; i++) {
         painter.setPen(QPen(colorMap[i]));
-        painter.setBrush(QBrush(colorMap[i]));
         painter.drawRect(width() - 30,height() - 10 -i * 2, 20, 2);
     }
 


### PR DESCRIPTION
if the QBrush color of QPainter is set, some drawing methods will picture filled objects (e.g. `drawEllipse()`). In sonar widget, the `drawEllipse()` is used to draw the grid of scanning sonar image.