### PR TITLE
add distinct events for mouse press on legend item or plot area

### DIFF
--- a/src/plot2d/Plot2d.cc
+++ b/src/plot2d/Plot2d.cc
@@ -13,5 +13,11 @@ Plot2d::Plot2d(QWidget *parent):
 
 Plot2d::~Plot2d(){} 
 
+// wrapper function for ruby bindings
+void Plot2d::removeGraph(int index)
+{
+   QCustomPlot::removePlottable(index);
+}
+
 
 

--- a/src/plot2d/Plot2d.h
+++ b/src/plot2d/Plot2d.h
@@ -25,7 +25,7 @@ public slots:
     QObject *getLegend()const{return legend;}
     QObject *addGraph(QObject *key_axis,QObject* value_axis)
         {return QCustomPlot::addGraph(dynamic_cast<QCPAxis*>(key_axis),dynamic_cast<QCPAxis*>(value_axis));}
-    void removeGraph(QObject *graph){removeGraph(dynamic_cast<QCPGraph*>(graph));} 
+    void removeGraph(int index);
     QObject *getXAxis()const{return xAxis;}
     QObject *getXAxis2()const{return xAxis2;}
     QObject *getYAxis()const{return yAxis;}

--- a/src/plot2d/qcustomplot.cc
+++ b/src/plot2d/qcustomplot.cc
@@ -2956,6 +2956,30 @@ void QCPLegend::draw(QPainter *painter)
   painter->restore();
 }
 
+int QCPLegend::getItemIndex(const QPoint *point)
+{
+  if (!mVisible) return -1;
+    
+  int currentTop = mPosition.y() + mPaddingTop;
+  
+  for (int i=0; i<mItems.size(); ++i)
+  {
+    QSize itemSize = mItems.at(i)->size(QSize(mSize.width(), 0));
+    QPoint itemPosTopLeft = QPoint(mPosition.x()+mPaddingLeft, currentTop);
+    
+    if (point->x() >= itemPosTopLeft.x() &&
+        point->x() <= itemPosTopLeft.x()+itemSize.width() &&
+        point->y() >= itemPosTopLeft.y() &&
+        point->y() <= itemPosTopLeft.y()+itemSize.height()) 
+    {
+      return i;
+    }
+    
+    currentTop += itemSize.height()+mItemSpacing;
+  }
+  
+  return -1;
+}
 /*! \internal 
   
   Goes through similar steps as \ref draw and calculates the width and height needed to
@@ -5731,8 +5755,22 @@ void QCustomPlot::mousePressEvent(QMouseEvent *event)
     mDragStart = event->pos();
     mDragStartHorzRange = mRangeDragHorzAxis->range();
     mDragStartVertRange = mRangeDragVertAxis->range();
-  } else
+  } else 
+  {
     mDragging = false;
+  }
+  
+  // check if mouse press was on a legend item
+  int itemIdx = legend->getItemIndex(&event->pos());
+  
+  if (itemIdx >= 0) 
+  {
+    emit mousePressOnLegendItem(event, QVariant(itemIdx));
+  } else 
+  {  
+    emit mousePressOnPlotArea(event);
+  }
+  
   emit mousePress(event);
 }
 

--- a/src/plot2d/qcustomplot.h
+++ b/src/plot2d/qcustomplot.h
@@ -596,7 +596,8 @@ public slots:
   QSize iconSize() const { return mIconSize; }
   int iconTextPadding() const { return mIconTextPadding; }
   QPen iconBorderPen() const { return mIconBorderPen; }
-
+  int getItemIndex(const QPoint *point);
+  
   // setters:
   void setBorderPen(const QPen &pen);
   void setBrush(const QBrush &brush);
@@ -1046,6 +1047,8 @@ protected:
 signals:
   void mouseDoubleClick(QMouseEvent *event);
   void mousePress(QMouseEvent *event);
+  void mousePressOnLegendItem(QMouseEvent *event, QVariant itemIdx);
+  void mousePressOnPlotArea(QMouseEvent *event);
   void mouseMove(QMouseEvent *event);
   void mouseRelease(QMouseEvent *event);
   void mouseWheel(QWheelEvent *event);


### PR DESCRIPTION
... and add function to determine which legend item was clicked

- note: required for corresponding merge in gui-vizkit
- note: original removeGraph method was non-functional and lead to lockup with valid arguments, so removed it.