### PR TITLE
add getters for range & gain

### DIFF
--- a/src/sonar_widget/SonarWidget.cc
+++ b/src/sonar_widget/SonarWidget.cc
@@ -70,9 +70,19 @@ void SonarWidget::setGain(int value)
     slGain->setValue(value);
 }
 
+int SonarWidget::getGain() const
+{
+  return slGain->value();
+}
+
 void SonarWidget::setRange(int value)
 {
     slRange->setValue(value);
+}
+
+int SonarWidget::getRange() const
+{
+  return slRange->value();
 }
 
 void SonarWidget::setSectorScan(bool continuous, base::Angle left, base::Angle right)

--- a/src/sonar_widget/SonarWidget.h
+++ b/src/sonar_widget/SonarWidget.h
@@ -44,6 +44,8 @@ public slots:
     void setMinRange(int);
     void setSonarPalette(int);
     void enableAutoRanging(bool);
+    int getRange() const;
+    int getGain() const;
 
     // only for scanning sonars
     void setSectorScan(bool continuous, base::Angle left, base::Angle right);


### PR DESCRIPTION
When controlling a sonar component from the widget, this allows to initialize the component the first time it is available.