### PR TITLE
Do not look for qwt-qt4, instead qwt-qt5

### DIFF
--- a/cmake/FindQWT.cmake
+++ b/cmake/FindQWT.cmake
@@ -46,7 +46,7 @@
 find_path ( QWT_INCLUDE_DIR
   NAMES qwt_plot.h
   HINTS ${QT_INCLUDE_DIR} /usr/local/lib/qwt.framework/Headers
-  PATH_SUFFIXES qwt-qt4 qwt6
+  PATH_SUFFIXES qwt-qt5 qwt6
 )
 
 set ( QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR} )


### PR DESCRIPTION
This fixes rock_widget_collection linking against qwt for qt4 instead of qt5 on ubuntu

@planthaber, please merge.